### PR TITLE
BACKEND - CORREÇÃO AO ABRIR TICKET NOVO NÃO DEMONSTRAR A PRIMEIRA MENSAGEM

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -1491,8 +1491,10 @@ const handleMessage = async (
       order: [["createdAt", "DESC"]],
     });
 
-    if (unreadMessages === 0 && whatsapp.complationMessage && formatBody(whatsapp.complationMessage, contact).trim().toLowerCase() === lastMessage.body.trim().toLowerCase()) {
-        return;
+    if(lastMessage){
+      if (unreadMessages === 0 && whatsapp.complationMessage && formatBody(whatsapp.complationMessage, contact).trim().toLowerCase() === lastMessage.body.trim().toLowerCase()) {
+          return;
+      }
     }
 
     const ticket = await FindOrCreateTicketService(contact, wbot.id!, unreadMessages, companyId, groupContact);


### PR DESCRIPTION
Estava apresentando problema ao abrir a primeira conversa com o contato novo..
Estava procurando uma nova mensagem de onde não existia ainda.